### PR TITLE
certs: link host certs if present

### DIFF
--- a/bootstrap-script.sh
+++ b/bootstrap-script.sh
@@ -2,6 +2,19 @@
 
 set -xeuo pipefail
 
+declare -r HOST_CERTS="/.bottlerocket/certs"
+
+# Link host certs if present into container & run update-ca-trust
+link_host_certs() {
+  for cert in $(ls -1 "${HOST_CERTS}"); do
+    ln -s "${HOST_CERTS}/${cert}" "/etc/pki/ca-trust/source/anchors/${cert}"
+  done
+  # Update the CA trust to pickup the new certificates
+  update-ca-trust
+}
+
+[[ -d "${HOST_CERTS}" ]] && link_host_certs
+
 # Full path to the base64-encoded user data
 USER_DATA_PATH='/.bottlerocket/bootstrap-containers/current/user-data'
 


### PR DESCRIPTION
*Description of changes:*
This change links host certificates if it has been updated on the Bottlerocket host. It checks if the path /.bottlerocket/certs exists, if so links the certs to the ca-trust source.

*Test*
- Created the image and used it in Bottlerocket node 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
