### PR TITLE
Add bootstrap changes to support eks-pod-identity-agent with IAM-RA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ RUN dnf update -y && \
         xfsprogs \
         lvm2 \
         mdadm \
-        rsync && \
+        rsync \
+        gettext && \
     dnf clean all
 
 # Verify that all packages are installed
@@ -52,12 +53,14 @@ RUN \
     command -v mkfs.xfs && \
     command -v lvm && \
     command -v mdadm && \
-    command -v rsync
+    command -v rsync && \
+    command -v envsubst
 
 # Copy the wrapper script and EKS Hybrid setup scripts into the container
 COPY bootstrap-script.sh /usr/local/bin/bootstrap-script.sh
 COPY eks-hybrid-ssm-setup.sh /usr/local/bin/eks-hybrid-ssm-setup
 COPY eks-hybrid-iam-ra-setup.sh /usr/local/bin/eks-hybrid-iam-ra-setup
+COPY aws-signing-helper-update.service.in /usr/share/bootstrap/aws-signing-helper-update.service.in
 
 # Copy the SSM agent from the builder stage
 COPY --from=builder /usr/bin/amazon-ssm-agent /usr/local/bin/amazon-ssm-agent

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ check-iam-ra-setup:
 	@echo "Running IAM-RA setup check"
 	@OUTPUT=$$(docker run --rm --entrypoint /usr/bin/bash \
 		$(IMAGE_NAME) \
-		-c "cp /usr/bin/true /usr/bin/apiclient; eks-hybrid-iam-ra-setup --certificate=${TEST_NODE_CERT} --key=${TEST_NODE_KEY} --dry-run=true 2>&1 || true"); \
+		-c "eks-hybrid-iam-ra-setup --certificate=${TEST_NODE_CERT} --key=${TEST_NODE_KEY} --dry-run=true 2>&1 || true"); \
 	if echo "$$OUTPUT" | grep -q "${TEST_NODE_CERT}"; then \
 		echo "Test failed: certificate content found in output"; \
 		exit 1; \

--- a/aws-signing-helper-update.service.in
+++ b/aws-signing-helper-update.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=Service that runs aws_signing_helper update to keep the AWS credentials refreshed in ${EKS_HYBRID_SHARED_CREDENTIALS_FILE}.
+
+[Service]
+User=root
+Environment=AWS_SHARED_CREDENTIALS_FILE=${EKS_HYBRID_SHARED_CREDENTIALS_FILE}
+ExecStart=${SIGNING_HELPER_UPDATE_COMMAND}
+StandardOutput=journal
+StandardError=inherit
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/eks-hybrid-iam-ra-setup.sh
+++ b/eks-hybrid-iam-ra-setup.sh
@@ -3,7 +3,15 @@
 exec >&2
 set -eu -o pipefail
 
-declare -r SECRETS_DIR="/.bottlerocket/rootfs/root/.aws"
+declare -r HOST_ROOTFS="/.bottlerocket/rootfs"
+declare -r SECRETS_DIR="${HOST_ROOTFS}/root/.aws"
+declare -r EKS_HYBRID_AWS_DIR="/root/.aws/eks-hybrid"
+declare -r EKS_HYBRID_SHARED_CREDENTIALS_FILE="${EKS_HYBRID_AWS_DIR}/credentials"
+declare -r EKS_HYBRID_POD_IDENTITY_AWS_DIR="${HOST_ROOTFS}/var/eks-hybrid/.aws"
+declare -r SIGNING_HELPER_SERVICE="aws-signing-helper-update.service"
+declare -r SIGNING_HELPER_SERVICE_TEMPLATE_PATH="/usr/share/bootstrap/${SIGNING_HELPER_SERVICE}.in"
+declare -r SYSTEMD_UNIT_DIR="${HOST_ROOTFS}/run/systemd/system"
+declare -r SIGNING_HELPER_SERVICE_PATH="${SYSTEMD_UNIT_DIR}/${SIGNING_HELPER_SERVICE}"
 
 DRY_RUN="false"
 for opt in "$@"; do
@@ -43,6 +51,17 @@ if ! [ "${DRY_RUN}" = "true" ]; then
     fi
 fi
 
+get_aws-signing-helper-update_command() {
+    local credential_process_from_config
+    credential_process_from_config="$(AWS_CONFIG_FILE="$1" aws configure get profile.default.credential_process)"
+    if [ -n "${credential_process_from_config}" ]; then
+        echo "${credential_process_from_config/aws_signing_helper credential-process/aws_signing_helper update}"
+    else
+        echo "Error: No credential_process found in default profile" >&2
+        return 1
+    fi
+}
+
 cat << EOF > "${SECRETS_DIR}/node.crt"
 ${NODE_CERT_DATA}
 EOF
@@ -50,6 +69,20 @@ EOF
 cat << EOF > "${SECRETS_DIR}/node.key"
 ${NODE_KEY_DATA}
 EOF
+
+if [ "${DRY_RUN}" = "true" ]; then
+  exit 0
+fi
+
+SIGNING_HELPER_UPDATE_COMMAND="$(get_aws-signing-helper-update_command ${SECRETS_DIR}/config)"
+export EKS_HYBRID_SHARED_CREDENTIALS_FILE SIGNING_HELPER_UPDATE_COMMAND
+# shellcheck disable=SC2016 # we want to replace the variables verbatim
+envsubst '${EKS_HYBRID_SHARED_CREDENTIALS_FILE}:${SIGNING_HELPER_UPDATE_COMMAND}' \
+    < "${SIGNING_HELPER_SERVICE_TEMPLATE_PATH}" \
+    > "${SIGNING_HELPER_SERVICE_PATH}"
+chroot "${HOST_ROOTFS}" systemctl enable "${SIGNING_HELPER_SERVICE}" --no-reload --quiet
+mkdir -p "$(dirname "${EKS_HYBRID_POD_IDENTITY_AWS_DIR}")"
+ln -sf "${EKS_HYBRID_AWS_DIR}" "${EKS_HYBRID_POD_IDENTITY_AWS_DIR}"
 
 variant_id="$(apiclient get os.variant_id | jq -r '.os.variant_id')"
 version_id="$(apiclient get os.version_id | jq -r '.os.version_id')"


### PR DESCRIPTION
The eks-pod-identity-agent add-on requires AWS credentials to call the EKS Auth `AssumeRoleForPodIdentity` API which enables it to grant AWS resource access (based on the permissions of the assumed role) to other Pods in the cluster. The eks-pod-identity-agent Daemonset for Bottlerocket hybrid nodes [mounts](https://github.com/aws/eks-pod-identity-agent/blob/main/charts/eks-pod-identity-agent/values.yaml#L53-L56) the host path `/var/eks-hybrid/.aws` to consume AWS credentials present on the host at `/var/eks-hybrid/.aws/credentials`. We need some process that creates this credentials file and manages the rotation of these credentials. In case of the SSM credentials provider, the Bottlerocket control container generates a credentials file which is [symlinked](https://github.com/bottlerocket-os/bottlerocket-bootstrap-container/blob/develop/eks-hybrid-ssm-setup.sh#L77) to `/var/eks-hybrid/.aws` on the host, and the `amazon-ssm-agent` refreshes these credentials every 30 minutes or so. We follow the [symlink approach in nodeadm](https://github.com/abhay-krishna/eks-hybrid/blob/main/internal/ssm/daemon.go#L101) as well, albeit without the added abstraction of the control container. 

To achieve the same in the IAM-RA credentials provider, we are adding a systemd unit file which runs the `aws_signing_helper update` command. his aligns with [what nodeadm does](https://github.com/aws/eks-hybrid/blob/main/internal/iamrolesanywhere/aws_signing_helper_update_service.tpl) to get pod-identity-agent working in other operating systems. This command creates (first invocation only) the AWS credentials file (`/root/.aws/credentials` by default but we're overriding this to `/var/eks-hybrid/.aws/credentials`) with temporary credentials and continuously updates them through a call to the IAM Roles Anywhere `CreateSession` API five minutes before the previous set of credentials are set to expire.

Changes:
1. Adding new systemd unit file that runs the `aws_signing_helper update` command. The systemd unit file is added as a template in the bootstrap container during build time, and the actual unit file is created on-the-fly through the script. For creating the unit file, I went with the approach of simply extracting the entire `aws_signing_helper credential-process` command from the `credential_process` field and replacing the `credential-process` with the `update` command. I did this to align with the values used in the `credential_process` field of the input AWS config and in favor of avoiding requiring the user to pass in additional arguments that they've already passed in the instance user-data.
2. Adding `gettext` to the list of installed packages, to be able to use the `envsubst` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
