### PR TITLE
fix: replace dnf update with dnf upgrade --releasever=latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN : "${IMAGE_VERSION:?IMAGE_VERSION is required to build}"
 LABEL "org.opencontainers.image.version"="$IMAGE_VERSION"
 
 # Install necessary packages
-RUN dnf update -y && \
+RUN dnf upgrade -y --releasever=latest && \
     dnf install -y \
         aws-cli \
         jq \


### PR DESCRIPTION
**Description of changes:**

AL2023 base container images are pinned to a specific release version for reproducibility. A plain `dnf upgrade` will only pull packages from that pinned release, which defeats the purpose of updating to the latest available patches.

`--releasever=latest` overrides the version lock and tells `dnf` to fetch from the latest AL2023 release repositories, which is the equivalent behavior to what `yum update` gave us on AL2.

NOTE: Since we're only grabbing the binaries from `amazon-ssm-agent`, we don't necessarily need to do this in the builder image.

**Testing done:**

`make`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
